### PR TITLE
runner + u22 installer updates

### DIFF
--- a/.github/workflows/build_from_source_on_Ubuntu_jammy_22_04.yml
+++ b/.github/workflows/build_from_source_on_Ubuntu_jammy_22_04.yml
@@ -33,5 +33,6 @@ jobs:
           cd openmc_install_scripts/Ubuntu_22.04
           ./openmc-install.sh
       - name: as a test run openmc
+        run: |
           which openmc
           openmc --version

--- a/Ubuntu_22.04/dagmc-install.sh
+++ b/Ubuntu_22.04/dagmc-install.sh
@@ -48,7 +48,7 @@ if [ ! -e ${name}.done ]; then
                -DBUILD_STATIC_EXE=OFF \
                -DBUILD_STATIC_LIBS=OFF \
                -DCMAKE_INSTALL_PREFIX=${install_prefix} \
-               -DDOUBLE_DOWN_DIR=${install_prefix}
+               -DDOUBLE_DOWN_DIR=$HOME/openmc/double-down
   make -j $ccores
   make install
 

--- a/Ubuntu_22.04/dagmc-install.sh
+++ b/Ubuntu_22.04/dagmc-install.sh
@@ -29,6 +29,10 @@ if [ ! -e ${name}.done ]; then
   if [ "x$1" != "x" ]; then
 	ccores=$1
   fi
+  # gitlab runner...
+  if [ $ccores == 0 ]; then
+    ccores=1
+  fi
 
   mkdir -p $HOME/openmc/DAGMC
   cd $HOME/openmc/DAGMC

--- a/Ubuntu_22.04/dagmc-install.sh
+++ b/Ubuntu_22.04/dagmc-install.sh
@@ -12,6 +12,13 @@ WD=`pwd`
 name=`basename $0`
 package_name='dagmc'
 
+install_prefix="/opt"
+if [ "x" != "x$LOCAL_INSTALL_PREFIX" ]; then
+  install_prefix=$LOCAL_INSTALL_PREFIX
+fi
+build_prefix="$HOME/openmc"
+
+
 #if there is a .done-file then skip this step
 if [ ! -e ${name}.done ]; then
 
@@ -25,16 +32,23 @@ if [ ! -e ${name}.done ]; then
 
   mkdir -p $HOME/openmc/DAGMC
   cd $HOME/openmc/DAGMC
-  git clone --single-branch --branch develop --depth 1 https://github.com/svalinn/DAGMC.git
-  mkdir build
+  if [ ! -e DAGMC ]; then
+    git clone --single-branch --branch develop --depth 1 https://github.com/svalinn/DAGMC.git
+    cd DAGMC
+  else
+    cd DAGMC; git pull
+  fi
+  
+  cd ..
+  mkdir -p build
   cd build
   cmake ../DAGMC -DBUILD_TALLY=ON \
-               -DMOAB_DIR=$HOME/openmc/MOAB \
+               -DMOAB_DIR=${install_prefix} \
                -DDOUBLE_DOWN=ON \
                -DBUILD_STATIC_EXE=OFF \
                -DBUILD_STATIC_LIBS=OFF \
-               -DCMAKE_INSTALL_PREFIX=$HOME/openmc/DAGMC/ \
-               -DDOUBLE_DOWN_DIR=$HOME/openmc/double-down
+               -DCMAKE_INSTALL_PREFIX=${install_prefix} \
+               -DDOUBLE_DOWN_DIR=${install_prefix}
   make -j $ccores
   make install
 

--- a/Ubuntu_22.04/openmc-install.sh
+++ b/Ubuntu_22.04/openmc-install.sh
@@ -14,6 +14,12 @@ echo "Compiled & installed dagmc, proceeding..."
 
 WD=`pwd`
 name=`basename $0`
+
+install_prefix="/opt"
+if [ "x" != "x$LOCAL_INSTALL_PREFIX" ]; then
+  install_prefix=$LOCAL_INSTALL_PREFIX
+fi
+
 #if there is a .done-file then skip this step
 if [ ! -e ${name}.done ]; then
   sudo apt-get install --yes libpng-dev libpng++-dev\
@@ -49,7 +55,7 @@ if [ ! -e ${name}.done ]; then
   mkdir -p build
   cd build
   cmake -DOPENMC_USE_DAGMC=ON \
-        -DDAGMC_ROOT=$HOME/openmc/DAGMC \
+        -DDAGMC_ROOT=${install_prefix}/openmc/DAGMC \
         -DHDF5_PREFER_PARALLEL=off ..
   make -j $ccores
   sudo make install


### PR DESCRIPTION
3 files were modified to result in a successful build on ubuntu22 with the gitlab runner:

- syntax error fix in the runner file
- install paths consistency between moab, double-down, dagmc and openmc
- dagmc hotfix for the core-count